### PR TITLE
Improve rendering performance

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -8,8 +8,6 @@ html {
 }
 body {
   background: #E74C3C;
-  background-image: linear-gradient(-180deg, rgba(255,255,255,0.16) 0%, rgba(192,56,43,0.16) 100%);
-  background-attachment: fixed;
   font-family: 'Lucida Grande', 'Trebuchet MS', sans-serif;
 }
 


### PR DESCRIPTION
Currently the scrolling is laggy when scrolling fast. This is probably because of the `background-attachment` CSS property which is set on the root element, but can also be caused because of the event listeners for touch move.
