### PR TITLE
Minify CSS & JS files on production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 
 var gulp 		      = require('gulp'),
+  util            = require('gulp-util');
  	sass 		        = require('gulp-sass'),
   browserSync     = require('browser-sync').create(),
 	injectPartials  = require('gulp-inject-partials'),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ gulp.task('sass', ['inline-svg'], function () {
   return gulp.src('./src/sass/*.scss')
     .pipe(sass().on('error', sass.logError))
     .pipe(prefix({ browsers: ['last 3 versions'] }))
+    .pipe(config.production ? cssmin() : util.noop())
     .pipe(gulp.dest('./dist/css'))
     .pipe(browserSync.stream());
 });
@@ -71,16 +72,19 @@ gulp.task('rollup', function() {
   }).catch(err => {
     console.log(err);
   });
+
+  // Minify for production
+  if (config.production) {
+    gulp.src(dest)
+      .pipe(uglify())
+      .pipe(gulp.dest('./dist/js'));
+  }
 });
 
 // Builds the app in ./dist
 gulp.task('build', ['index', 'inline-svg', 'sass', 'rollup', 'images'], function() {
   gulp.src(['./src/html/*', '!./src/html/*.html'])
     .pipe(gulp.dest('./dist'));
-});
-
-gulp.task('build:production', ['build', 'index:production'], function() {
-
 });
 
 gulp.task('serve', ['build'], function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,23 +13,19 @@ var gulp 		      = require('gulp'),
   rollup          = require('rollup'),
   buble           = require('rollup-plugin-buble');
 
+var config = {
+  production: !!util.env.production
+}
+
 // Handles partials injection on index.html
 gulp.task('index', function () {
   return gulp.src('./src/html/index.html')
            .pipe(injectPartials({
              removeTags: true
            }))
+           .pipe(config.production ? processhtml() : util.noop())
            .pipe(gulp.dest('./dist'))
            .pipe(browserSync.stream());
-});
-
-gulp.task('index:production', function() {
-  return gulp.src('./src/html/index.html')
-           .pipe(injectPartials({
-             removeTags: true
-           }))
-           .pipe(processhtml())
-           .pipe(gulp.dest('./dist'));
 });
 
 // Compiles, prefixes and minifies style.scss & fruits.scss

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "gulp-inline-svg": "^1.1.1",
     "gulp-processhtml": "^1.1.0",
     "gulp-sass": "^2.3.2",
-    "gulp-uglify": "^2.0.0"
+    "gulp-uglify": "^2.0.0",
+    "gulp-util": "^3.0.7"
   },
   "devDependencies": {
     "jasmine-core": "^2.5.1",


### PR DESCRIPTION
Improved gulpfile - added support for production flag to minify CSS & JS files, and process html production flags.
